### PR TITLE
Use `dropDatabase` mongoose helper

### DIFF
--- a/test/api/helpers/db/db_util.js
+++ b/test/api/helpers/db/db_util.js
@@ -28,7 +28,7 @@ function rebuildIndexes(done) {
 }
 
 module.exports.cleanDatabase = function(done) {
-  mongoose.connection.db.dropDatabase(function() {
+  mongoose.connection.dropDatabase(function() {
     rebuildIndexes(done);
   });
 };


### PR DESCRIPTION
On archlinux w/ mongodb v3.4.1 and mongoose v4.6.4, I ran into
github.com/Automattic/mongoose/issues/4634 when running tests

This change uses the `dropDatabase` mongoose helper instead of
bypassing mongoose via `db.dropDatabase`