### PR TITLE
Add pagination via mongoose-paginate

### DIFF
--- a/api/data/enterprise.model.js
+++ b/api/data/enterprise.model.js
@@ -1,6 +1,7 @@
 const logger = require('../../lib/logger');
 const mongoose = require('mongoose');
 const SUPPORTED_LANGUAGES = require('../helpers/language/constants').SUPPORTED_LANGUAGES;
+const mongoosePaginate = require('mongoose-paginate');
 
 let directoryAdministratorsSchema = new mongoose.Schema({
   email: String
@@ -98,6 +99,8 @@ let enterprisePublicSchema = new mongoose.Schema({
   }]
 }, { _id : false });
 
+enterprisePublicSchema.plugin(mongoosePaginate);
+
 // Create index for sorting by name
 enterprisePublicSchema.index({lowercase_name: 1});
 
@@ -138,6 +141,8 @@ SUPPORTED_LANGUAGES.forEach(lang => {
   internationalFields[lang] = { type: enterprisePublicSchema, _id: false };
 });
 let enterpriseInternationalPublicSchema = new mongoose.Schema(internationalFields);
+
+enterpriseInternationalPublicSchema.plugin(mongoosePaginate);
 
 enterpriseInternationalPublicSchema.index({ locations : '2dsphere' });
 

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -170,9 +170,9 @@ paths:
       # call this method name on the controller
       operationId: getAllEnterprisesPublic
       parameters:
-        - name: offset
+        - name: page
           in: query
-          description: Skip the first number of enterprises specified by offset value
+          description: Skip the first number of pages specified by page value
           required: false
           type: number
           format: uint

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -137,6 +137,11 @@
       "from": "caseless@>=0.12.0 <0.13.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
     },
+    "chalk": {
+      "version": "1.1.3",
+      "from": "chalk@>=1.1.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+    },
     "chance": {
       "version": "1.0.8",
       "from": "chance@>=1.0.1 <1.1.0",
@@ -159,7 +164,7 @@
     },
     "commander": {
       "version": "2.9.0",
-      "from": "commander@>=2.9.0 <3.0.0",
+      "from": "commander@2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
     },
     "component-emitter": {
@@ -558,6 +563,58 @@
       "from": "ipaddr.js@1.3.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz"
     },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.15.0",
+      "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz"
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "from": "is-path-cwd@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "1.0.0",
+      "from": "is-path-inside@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "from": "is-plain-obj@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "from": "is-property@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "from": "is-regexp@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.0.0",
+      "from": "is-resolvable@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "dev": true
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "from": "is-typedarray@>=1.0.0 <1.1.0",
@@ -664,7 +721,7 @@
     },
     "lodash": {
       "version": "4.17.4",
-      "from": "lodash@>=4.14.0 <5.0.0",
+      "from": "lodash@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
     },
     "lodash.get": {
@@ -772,7 +829,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@>=0.5.1 <0.6.0",
+      "from": "mkdirp@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
     },
     "mongodb": {
@@ -789,6 +846,18 @@
       "version": "4.9.8",
       "from": "mongoose@4.9.8",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.9.8.tgz"
+    },
+    "mongoose-paginate": {
+      "version": "5.0.3",
+      "from": "mongoose-paginate@latest",
+      "resolved": "https://registry.npmjs.org/mongoose-paginate/-/mongoose-paginate-5.0.3.tgz",
+      "dependencies": {
+        "bluebird": {
+          "version": "3.0.5",
+          "from": "bluebird@3.0.5",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.0.5.tgz"
+        }
+      }
     },
     "mpath": {
       "version": "0.2.1",
@@ -1217,7 +1286,7 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "from": "typedarray@>=0.0.6 <0.0.7",
+      "from": "typedarray@>=0.0.5 <0.1.0",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "uid-safe": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "passport-facebook": "2.1.1",
     "passport-instagram": "1.0.0",
     "passport-twitter": "1.0.4",
+    "mongoose-paginate": "^5.0.3",
     "swagger-express-mw": "0.7.0",
     "winston": "2.3.1"
   },


### PR DESCRIPTION
The default number of returned enterprises is back to 25 (from 500).
(Reverts temporary commit 48592471af1ab29)

This changes the return value from an array of enterprises to an object:

```
{
  docs: [], // Array of enterprises
  total: , // Total number of matched enterprises (before `limit`)
  limit: , // Limit that was used
  offset: , // Offset that was used
}
```
This is a breaking change from API v1, we should proabably make this API
v2